### PR TITLE
Tests improve

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,4 @@ repos:
     hooks:
       - id: mypy
         args: [--strict, --ignore-missing-imports, --no-warn-unused-ignores, --allow-untyped-calls,]
+        files: ^src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,10 @@ exclude_lines = [
 line-length = 120
 
 [tool.pytest.ini_options]
+addopts = "-m 'not slow'"
+markers = [
+    "slow: real-data tests hitting files on /mnt/summer; excluded by default, run with `pytest -m slow`",
+]
 filterwarnings = [
     "error",
     "ignore::UserWarning",

--- a/tests/kh9pc/conftest.py
+++ b/tests/kh9pc/conftest.py
@@ -1,0 +1,75 @@
+"""
+Copyright (c) 2026 HIPP developers
+Description: some fixture for kh9pc tests
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from hipp.kh9pc.restitution.poly_strategy import PolyStrategy
+from hipp.kh9pc.restitution.vertical_detector import VerticalDetector
+
+
+@dataclass
+class JoinedImage:
+    """A sample joined-image scan with its reference (left, right, top, bottom) edges."""
+
+    path: Path
+    expected_edges: tuple[int, int, int, int]
+
+
+@pytest.fixture(scope="session")
+def joined_image_1() -> JoinedImage:
+    """Image to test the vertical detection with a dark right edge, with its reference
+    (left, right, top, bottom) edges"""
+    return JoinedImage(
+        path=Path("/mnt/summer/USERS/DEHECQA/DIVERGENCE/outputs/KH9_PC/work/joined_images/D3C1201-100059F032.tif"),
+        expected_edges=(4880, 234065, 945, 22966),  # top/bottom are placeholder values
+    )
+
+
+@pytest.fixture(scope="session")
+def joined_image_2() -> JoinedImage:
+    """Image to test the vertical detection with the next image at the right side of the film, with its
+    reference (left, right, top, bottom) edges"""
+    return JoinedImage(
+        path=Path("/mnt/summer/USERS/DEHECQA/DIVERGENCE/outputs/KH9_PC/work/joined_images/D3C1204-300473A013.tif"),
+        expected_edges=(5610, 235169, 1642, 23823),  # top/bottom are placeholder values
+    )
+
+
+@pytest.fixture(scope="session")
+def joined_image_3() -> JoinedImage:
+    """Image with a halo on the left side, with its reference (left, right, top, bottom) edges"""
+    return JoinedImage(
+        path=Path("/mnt/summer/USERS/DEHECQA/DIVERGENCE/outputs/KH9_PC/work/joined_images/D3C1204-300473F013.tif"),
+        expected_edges=(3810, 232675, 1494, 23692),  # top/bottom are placeholder values
+    )
+
+
+@pytest.fixture(scope="session", params=["joined_image_1", "joined_image_2", "joined_image_3"])
+def joined_image(request: pytest.FixtureRequest) -> JoinedImage:
+    """Parametrized indirection over the joined_image_* fixtures, one per sample scan."""
+    image: JoinedImage = request.getfixturevalue(request.param)
+    return image
+
+
+@pytest.fixture(scope="session")
+def fitted_vertical_detector(joined_image: JoinedImage) -> VerticalDetector:
+    """Real VerticalDetector fitted once per joined_image and cached for the session.
+
+    Reused by downstream strategies (PolyStrategy, ...) so the slow edge detection
+    runs only once per sample and its actual output feeds the next stage.
+    """
+    return VerticalDetector().fit(joined_image.path)
+
+
+@pytest.fixture(scope="session")
+def fitted_poly_strategy(fitted_vertical_detector: VerticalDetector, joined_image: JoinedImage) -> PolyStrategy:
+    """Real PolyStrategy fitted once per joined_image on top of fitted_vertical_detector.
+
+    Reused by downstream strategies (FiducialStrategy, ...) for the same reason.
+    """
+    return PolyStrategy(vertical_detector=fitted_vertical_detector).fit(joined_image.path)

--- a/tests/kh9pc/test_fiducial_strategy.py
+++ b/tests/kh9pc/test_fiducial_strategy.py
@@ -1,0 +1,17 @@
+"""
+Copyright (c) 2026 HIPP developers
+Description: tests for the class FiducialStrategy
+"""
+
+import pytest
+
+from conftest import JoinedImage
+from hipp.kh9pc.restitution.fiducial_strategy import FiducialStrategy
+from hipp.kh9pc.restitution.poly_strategy import PolyStrategy
+
+
+@pytest.mark.slow()
+def test_fiducial_strategy(fitted_poly_strategy: PolyStrategy, joined_image: JoinedImage) -> None:
+    strategy = FiducialStrategy(poly_strategy=fitted_poly_strategy).fit(joined_image.path)
+
+    assert not strategy.is_failed

--- a/tests/kh9pc/test_poly_strategy.py
+++ b/tests/kh9pc/test_poly_strategy.py
@@ -1,0 +1,30 @@
+"""
+Copyright (c) 2026 HIPP developers
+Description: tests for the class PolyStrategy
+"""
+
+import numpy as np
+import pytest
+
+from conftest import JoinedImage
+from hipp.kh9pc.kh9_image_spec import KH9ImageSpec
+from hipp.kh9pc.restitution.poly_strategy import PolyStrategy
+
+ABS_TOLERANCE = 100
+REL_TOLERANCE = 0.02
+
+
+@pytest.mark.slow()
+def test_poly_strategy(fitted_poly_strategy: PolyStrategy, joined_image: JoinedImage) -> None:
+    left, right, top, bottom = joined_image.expected_edges
+    cx = left + (right - left) // 2
+
+    cy_top = fitted_poly_strategy.top_.model.predict(np.array([[cx]])).ravel()[0]
+    cy_bottom = fitted_poly_strategy.bottom_.model.predict(np.array([[cx]])).ravel()[0]
+
+    expected_height = KH9ImageSpec.expected_size_from_file(joined_image.path)[1]
+
+    assert not fitted_poly_strategy.is_failed
+    assert cy_top == pytest.approx(top, abs=ABS_TOLERANCE)
+    assert cy_bottom == pytest.approx(bottom, abs=ABS_TOLERANCE)
+    assert cy_bottom - cy_top == pytest.approx(expected_height, rel=REL_TOLERANCE)

--- a/tests/kh9pc/test_vertical_detection.py
+++ b/tests/kh9pc/test_vertical_detection.py
@@ -1,0 +1,25 @@
+"""
+Copyright (c) 2026 HIPP developers
+Description: tests for the class VerticalDetector
+"""
+
+import pytest
+
+from conftest import JoinedImage
+from hipp.kh9pc.kh9_image_spec import KH9ImageSpec
+from hipp.kh9pc.restitution.vertical_detector import VerticalDetector
+
+EDGE_ABS_TOLERANCE = 100
+WIDTH_REL_TOLERANCE = 0.02
+
+
+@pytest.mark.slow()
+def test_vertical_detection(fitted_vertical_detector: VerticalDetector, joined_image: JoinedImage) -> None:
+    left, right = fitted_vertical_detector.edges_
+    expected_left, expected_right, _, _ = joined_image.expected_edges
+
+    expected_width = KH9ImageSpec.from_raster_filepath(joined_image.path).expected_size[0]
+
+    assert left == pytest.approx(expected_left, abs=EDGE_ABS_TOLERANCE)
+    assert right == pytest.approx(expected_right, abs=EDGE_ABS_TOLERANCE)
+    assert fitted_vertical_detector.detected_width_ == pytest.approx(expected_width, rel=WIDTH_REL_TOLERANCE)


### PR DESCRIPTION
Add tests for `VerticalDetector`, `PolyStrategy` and `FIducialStrategy`. 
Those tests are marked slow to not be ran by default.

> Note : For the moment those tests not include the downloading of images.